### PR TITLE
feat: 国际化修复、性能优化与 AI commit 生成修复

### DIFF
--- a/src/ForkPlus/Accounts/AiServices/OpenAiService.cs
+++ b/src/ForkPlus/Accounts/AiServices/OpenAiService.cs
@@ -258,7 +258,18 @@ namespace ForkPlus.Accounts.AiServices
 				{
 					return LocalizeCancellationError(result);
 				}
-				if (IsQueuedWaitError(result.Error, out int queuedDelaySeconds))
+				int queuedDelaySeconds;
+				bool isQueuedWait = IsQueuedWaitError(result.Error, out queuedDelaySeconds);
+				if (!isQueuedWait)
+				{
+					string message = result.Error?.FriendlyMessage ?? "";
+					if (IsTransientServiceMessage(message))
+					{
+						isQueuedWait = true;
+						queuedDelaySeconds = 30;
+					}
+				}
+				if (isQueuedWait)
 				{
 					int remainingQueuedWaitSeconds = Math.Max(0, maxQueuedWaitSeconds - queuedWaitSeconds);
 					if (remainingQueuedWaitSeconds <= 0)
@@ -426,12 +437,26 @@ namespace ForkPlus.Accounts.AiServices
 				|| message.IndexOf("eta", StringComparison.OrdinalIgnoreCase) >= 0
 				|| message.IndexOf("estimated", StringComparison.OrdinalIgnoreCase) >= 0
 				|| message.IndexOf("pending", StringComparison.OrdinalIgnoreCase) >= 0
+				|| message.IndexOf("busy", StringComparison.OrdinalIgnoreCase) >= 0
+				|| message.IndexOf("overload", StringComparison.OrdinalIgnoreCase) >= 0
+				|| message.IndexOf("rate limit", StringComparison.OrdinalIgnoreCase) >= 0
+				|| message.IndexOf("too many requests", StringComparison.OrdinalIgnoreCase) >= 0
+				|| message.IndexOf("try again", StringComparison.OrdinalIgnoreCase) >= 0
+				|| message.IndexOf("temporarily unavailable", StringComparison.OrdinalIgnoreCase) >= 0
+				|| message.IndexOf("service unavailable", StringComparison.OrdinalIgnoreCase) >= 0
+				|| message.IndexOf("model is loading", StringComparison.OrdinalIgnoreCase) >= 0
 				|| message.Contains("排队")
 				|| message.Contains("隊列")
 				|| message.Contains("队列")
 				|| message.Contains("等待")
 				|| message.Contains("預計")
-				|| message.Contains("预计");
+				|| message.Contains("预计")
+				|| message.Contains("繁忙")
+				|| message.Contains("稍后")
+				|| message.Contains("稍後")
+				|| message.Contains("限流")
+				|| message.Contains("频率")
+				|| message.Contains("頻率");
 		}
 
 		private static int MaxQueuedWaitSeconds()

--- a/src/ForkPlus/Accounts/NotificationManager.cs
+++ b/src/ForkPlus/Accounts/NotificationManager.cs
@@ -212,9 +212,11 @@ namespace ForkPlus.Accounts
 		}
 
 		private void SendToastNotification(int newNotificationsCount)
-		{
-			SendWindowsNotification($"<?xml version=\"1.0\" encoding =\"utf-8\" ?>\n<toast>\n<audio silent=\"true\"/>\n<visual>\n    <binding template=\"ToastGeneric\">\n        <text hint-maxLines=\"1\">New Notifications</text>\n        <text>You've got {newNotificationsCount} new notifications</text>\n    </binding>\n</visual>\n</toast>\n");
-		}
+	{
+		string title = PreferencesLocalization.Current("New Notifications");
+		string body = PreferencesLocalization.FormatCurrent("You've got {0} new notifications", newNotificationsCount);
+		SendWindowsNotification($"<?xml version=\"1.0\" encoding =\"utf-8\" ?>\n<toast>\n<audio silent=\"true\"/>\n<visual>\n    <binding template=\"ToastGeneric\">\n        <text hint-maxLines=\"1\">{WebUtility.HtmlEncode(title)}</text>\n        <text>{WebUtility.HtmlEncode(body)}</text>\n    </binding>\n</visual>\n</toast>\n");
+	}
 
 		private void SendToastNotification(GitServiceNotification notification)
 		{

--- a/src/ForkPlus/App.xaml.cs
+++ b/src/ForkPlus/App.xaml.cs
@@ -507,7 +507,7 @@ namespace ForkPlus
 			SubscribeToUserPreferences();
 			if (!Environment.Is64BitOperatingSystem)
 			{
-				MessageBox.Show("Currently Fork doesn't support 32-bit Windows");
+				MessageBox.Show(ForkPlus.UI.UserControls.Preferences.PreferencesLocalization.Current("Currently Fork doesn't support 32-bit Windows"));
 			}
 			else if (IsDebug || InitializeForkInstance())
 			{

--- a/src/ForkPlus/Languages/zh-Hans.json
+++ b/src/ForkPlus/Languages/zh-Hans.json
@@ -1596,6 +1596,7 @@
     "Cannot get diff:\n": "无法获取差异：\n",
     "Changes are too large (": "变更过大（",
     "Changes are too large to display": "变更过大，无法显示",
+    "File has no changes": "文件无修改",
     "Load Diff": "加载差异",
     "Select two commits to see difference between them": "选择两个提交以查看它们之间的差异",
     "Search SHA, branch, author or message": "搜索 SHA、分支、作者或消息",

--- a/src/ForkPlus/Languages/zh-Hans.json
+++ b/src/ForkPlus/Languages/zh-Hans.json
@@ -1839,6 +1839,14 @@
     "fatal: cannot hash {0}": "致命错误：无法计算 {0} 的哈希值",
     "fatal: cannot hash": "致命错误：无法计算哈希值",
     "error: open({0}): Permission denied": "错误：打开{0}时权限被拒绝",
-    "Allowed parameters:": "允许的参数："
+    "Allowed parameters:": "允许的参数：",
+    "New Notifications": "新通知",
+    "You've got {0} new notifications": "您有 {0} 条新通知",
+    "Currently Fork doesn't support 32-bit Windows": "目前 Fork 不支持 32 位 Windows",
+    "Select skill file": "选择技能文件",
+    "Text files (*.md;*.txt)": "文本文件 (*.md;*.txt)",
+    "All files (*.*)": "所有文件 (*.*)",
+    "Failed to load file '{0}': {1}": "加载文件 '{0}' 失败：{1}",
+    "Move the '{0}' branch HEAD to the selected revision": "将 '{0}' 分支的 HEAD 移动到所选修订"
   }
 }

--- a/src/ForkPlus/Languages/zh-Hant.json
+++ b/src/ForkPlus/Languages/zh-Hant.json
@@ -1596,6 +1596,7 @@
     "Cannot get diff:\n": "無法取得差異：\n",
     "Changes are too large (": "變更過大（",
     "Changes are too large to display": "變更過大，無法顯示",
+    "File has no changes": "檔案無修改",
     "Load Diff": "載入差異",
     "Select two commits to see difference between them": "選擇兩個提交以查看它們之間的差異",
     "Search SHA, branch, author or message": "搜尋 SHA、分支、作者或訊息",

--- a/src/ForkPlus/Languages/zh-Hant.json
+++ b/src/ForkPlus/Languages/zh-Hant.json
@@ -1839,6 +1839,14 @@
     "fatal: cannot hash {0}": "致命錯誤：無法計算 {0} 的雜湊值",
     "fatal: cannot hash": "致命錯誤：無法計算雜湊值",
     "error: open({0}): Permission denied": "錯誤：打開{0}時權限被拒絕",
-    "Allowed parameters:": "允許的參數："
+    "Allowed parameters:": "允許的參數：",
+    "New Notifications": "新通知",
+    "You've got {0} new notifications": "您有 {0} 則新通知",
+    "Currently Fork doesn't support 32-bit Windows": "目前 Fork 不支援 32 位元 Windows",
+    "Select skill file": "選擇技能檔案",
+    "Text files (*.md;*.txt)": "文字檔案 (*.md;*.txt)",
+    "All files (*.*)": "所有檔案 (*.*)",
+    "Failed to load file '{0}': {1}": "載入檔案 '{0}' 失敗：{1}",
+    "Move the '{0}' branch HEAD to the selected revision": "將 '{0}' 分支的 HEAD 移動到所選修訂"
   }
 }

--- a/src/ForkPlus/UI/Controls/FileDiffControl.cs
+++ b/src/ForkPlus/UI/Controls/FileDiffControl.cs
@@ -181,20 +181,10 @@ namespace ForkPlus.UI.Controls
 				Diff diff2 = parsedDiffContent.Diff;
 				if (diff2 == null)
 				{
-					ShowSubView(delegate
+					ShowSubView(() => new FallbackUserControl(), delegate(FallbackUserControl c, FileControlHeaderUserControl h)
 					{
-						TextDiffControl textDiffControl4 = new TextDiffControl(Target);
-						if (SubControlMode)
-						{
-							textDiffControl4.VerticalScrollBarVisibility = ScrollBarVisibility.Hidden;
-							textDiffControl4.PreviewMouseWheel += DiffCodeEditor_PreviewMouseWheel;
-						}
-						textDiffControl4.PositionCache = _positionCache;
-						return textDiffControl4;
-					}, delegate(TextDiffControl c, FileControlHeaderUserControl h)
-					{
-						c.SetDiff(diff2, parsedDiffContent.TabWidth, parsedDiffContent.EntireFile, DiffLocation.Revision);
-						ShowHeaderIfAllowed(h, changedFile, FileControlHeaderMode.Text);
+						h.Collapse();
+						c.FallbackMessage = PreferencesLocalization.Current("File has no changes");
 					});
 				}
 				else if (diff2.Type == Diff.FileType.Text)

--- a/src/ForkPlus/UI/Dialogs/Accounts/AccountsWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/Accounts/AccountsWindow.xaml.cs
@@ -25,7 +25,7 @@ namespace ForkPlus.UI.Dialogs.Accounts
 			base.ResizeMode = ResizeMode.CanResizeWithGrip;
 			Refresh();
 			AccountsListBox.SelectedItem = _accountViewModels.FirstOrDefault();
-			base.CancelButtonTitle = "Close";
+			base.CancelButtonTitle = Translate("Close");
 			base.ShowSubmitButton = false;
 			AccountDetailsUserControl.AccountTabItem.UpdateTokenButtonClicked += AccountDetailsUserControl_UpdateTokenButtonClicked;
 		}

--- a/src/ForkPlus/UI/Dialogs/Accounts/AddAccountWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/Accounts/AddAccountWindow.xaml.cs
@@ -6,6 +6,7 @@ using System.Windows.Input;
 using System.Windows.Markup;
 using System.Windows.Media;
 using ForkPlus.Git;
+using ForkPlus.UI.UserControls.Preferences;
 
 namespace ForkPlus.UI.Dialogs.Accounts
 {
@@ -58,7 +59,7 @@ namespace ForkPlus.UI.Dialogs.Accounts
 			base.ShowLogo = false;
 			base.ShowHeader = false;
 			InitializeComponent();
-			base.SubmitButtonTitle = "Log in";
+			base.SubmitButtonTitle = PreferencesLocalization.Current("Log in");
 			ServicesListBox.ItemsSource = _servicesViewModels;
 		}
 

--- a/src/ForkPlus/UI/Dialogs/Accounts/BitbucketLoginWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/Accounts/BitbucketLoginWindow.xaml.cs
@@ -53,7 +53,7 @@ namespace ForkPlus.UI.Dialogs.Accounts
 			base.ShowLogo = false;
 			base.ShowHeader = false;
 			InitializeComponent();
-			base.SubmitButtonTitle = "Sign In";
+			base.SubmitButtonTitle = Translate("Sign In");
 			Account = account;
 			AuthenticationTypeComboBox.ItemsSource = _authenticationItems;
 			SelectAuthenticationType(AuthenticationType.AccessToken);

--- a/src/ForkPlus/UI/Dialogs/Accounts/BitbucketServerLoginWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/Accounts/BitbucketServerLoginWindow.xaml.cs
@@ -41,7 +41,7 @@ namespace ForkPlus.UI.Dialogs.Accounts
 			base.ShowLogo = false;
 			base.ShowHeader = false;
 			InitializeComponent();
-			base.SubmitButtonTitle = "Sign In";
+			base.SubmitButtonTitle = PreferencesLocalization.Current("Sign In");
 			Account = account;
 			ServerTextBox.Text = account?.ServerUrl;
 			ServerTextBox.TextChanged += delegate

--- a/src/ForkPlus/UI/Dialogs/Accounts/GitHubEnterpriseLoginWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/Accounts/GitHubEnterpriseLoginWindow.xaml.cs
@@ -41,7 +41,7 @@ namespace ForkPlus.UI.Dialogs.Accounts
 			base.ShowLogo = false;
 			base.ShowHeader = false;
 			InitializeComponent();
-			base.SubmitButtonTitle = "Sign In";
+			base.SubmitButtonTitle = PreferencesLocalization.Current("Sign In");
 			Account = account;
 			ServerTextBox.Text = account?.ServerUrl;
 			ServerTextBox.TextChanged += delegate

--- a/src/ForkPlus/UI/Dialogs/Accounts/GitHubLoginWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/Accounts/GitHubLoginWindow.xaml.cs
@@ -52,7 +52,7 @@ namespace ForkPlus.UI.Dialogs.Accounts
 			base.ShowLogo = false;
 			base.ShowHeader = false;
 			InitializeComponent();
-			base.SubmitButtonTitle = "Sign In";
+			base.SubmitButtonTitle = PreferencesLocalization.Current("Sign In");
 			Account = account;
 			AuthenticationTypeComboBox.ItemsSource = _authenticationItems;
 			SelectAuthenticationType(AuthenticationType.AccessToken);

--- a/src/ForkPlus/UI/Dialogs/Accounts/GitLabLoginWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/Accounts/GitLabLoginWindow.xaml.cs
@@ -58,7 +58,7 @@ namespace ForkPlus.UI.Dialogs.Accounts
 			base.ShowLogo = false;
 			base.ShowHeader = false;
 			InitializeComponent();
-			base.SubmitButtonTitle = "Sign In";
+			base.SubmitButtonTitle = Translate("Sign In");
 			OpenPersonalAccessTokenConfigurationUrlButton.ToolTip = Translate("Required scopes: read_user, read_api, read_repository, write_repository");
 			Account = account;
 			if (!server)

--- a/src/ForkPlus/UI/Dialogs/Accounts/GiteaLoginWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/Accounts/GiteaLoginWindow.xaml.cs
@@ -41,7 +41,7 @@ namespace ForkPlus.UI.Dialogs.Accounts
 			base.ShowLogo = false;
 			base.ShowHeader = false;
 			InitializeComponent();
-			base.SubmitButtonTitle = "Sign In";
+			base.SubmitButtonTitle = PreferencesLocalization.Current("Sign In");
 			Account = account;
 			ServerTextBox.Text = account?.ServerUrl;
 			ServerTextBox.TextChanged += delegate

--- a/src/ForkPlus/UI/Dialogs/Accounts/OpenAiLoginWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/Accounts/OpenAiLoginWindow.xaml.cs
@@ -31,7 +31,7 @@ namespace ForkPlus.UI.Dialogs.Accounts
 			base.ShowLogo = false;
 			base.ShowHeader = false;
 			InitializeComponent();
-			base.SubmitButtonTitle = "Sign In";
+			base.SubmitButtonTitle = PreferencesLocalization.Current("Sign In");
 			TokenTextBox.TextChanged += delegate
 			{
 				UpdateSubmitButton();

--- a/src/ForkPlus/UI/Dialogs/AddGitignoreTemplateWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/AddGitignoreTemplateWindow.xaml.cs
@@ -11,6 +11,7 @@ using System.Windows.Navigation;
 using ForkPlus.Git;
 using ForkPlus.UI.Controls.Editor;
 using ForkPlus.UI.UserControls;
+using ForkPlus.UI.UserControls.Preferences;
 
 namespace ForkPlus.UI.Dialogs
 {
@@ -131,8 +132,8 @@ namespace ForkPlus.UI.Dialogs
 			InitializeComponent();
 			_repositoryUserControl = repositoryUserControl;
 			_untrackedFiles = untrackedFiles;
-			base.DialogTitle = "Add .gitignore Template";
-			base.SubmitButtonTitle = "Add";
+			base.DialogTitle = PreferencesLocalization.Current("Add .gitignore Template");
+			base.SubmitButtonTitle = PreferencesLocalization.Current("Add");
 			base.DescriptionTextBlock.Inlines.Clear();
 			base.DescriptionTextBlock.Inlines.Add(new Run("Choose "));
 			Hyperlink hyperlink = new Hyperlink(new Run(".gitignore"));

--- a/src/ForkPlus/UI/Dialogs/AddSubmoduleWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/AddSubmoduleWindow.xaml.cs
@@ -40,9 +40,9 @@ namespace ForkPlus.UI.Dialogs
 			_submodulesToUpdate = submodulesToUpdate;
 			InitializeComponent();
 			base.ResizeMode = ResizeMode.CanResizeWithGrip;
-			base.DialogTitle = "Add Submodule";
-			base.DialogDescription = "Add new submodule repository reference";
-			base.SubmitButtonTitle = "Add Submodule";
+			base.DialogTitle = Translate("Add Submodule");
+			base.DialogDescription = Translate("Add new submodule repository reference");
+			base.SubmitButtonTitle = Translate("Add Submodule");
 			string text = TryGetClipboardRepositoryUrl();
 			if (!string.IsNullOrEmpty(text))
 			{

--- a/src/ForkPlus/UI/Dialogs/ApplyPatchWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/ApplyPatchWindow.xaml.cs
@@ -40,9 +40,9 @@ namespace ForkPlus.UI.Dialogs
 			_repositoryUserControl = repositoryUserControl;
 			_patchContainsCommitHeader = PatchContainsCommitHeader(patchPath);
 			InitializeComponent();
-			base.DialogTitle = "Apply Patch";
-			base.DialogDescription = "Apply Patch";
-			base.SubmitButtonTitle = "Apply";
+			base.DialogTitle = Translate("Apply Patch");
+			base.DialogDescription = Translate("Apply Patch");
+			base.SubmitButtonTitle = Translate("Apply");
 			PathTextBox.Text = patchPath;
 			PathTextBox.SelectAll();
 			RefreshCreateCommitsCheckBoxVisibility();
@@ -56,9 +56,9 @@ namespace ForkPlus.UI.Dialogs
 			string @string = Encoding.UTF8.GetString(patchData);
 			_patchContainsCommitHeader = @string.StartsWith("From ");
 			InitializeComponent();
-			base.DialogTitle = "Apply Patch";
-			base.DialogDescription = "Apply patch from clipboard";
-			base.SubmitButtonTitle = "Apply";
+			base.DialogTitle = Translate("Apply Patch");
+			base.DialogDescription = Translate("Apply patch from clipboard");
+			base.SubmitButtonTitle = Translate("Apply");
 			LocationLabel.Collapse();
 			PathTextBox.Collapse();
 			BrowseButton.Collapse();

--- a/src/ForkPlus/UI/Dialogs/ApplyStashWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/ApplyStashWindow.xaml.cs
@@ -25,9 +25,9 @@ namespace ForkPlus.UI.Dialogs
 			_repositoryUserControl = repositoryUserControl;
 			_stash = stash;
 			GitPointView.Value = _stash;
-			base.DialogTitle = "Apply Stash";
-			base.DialogDescription = "Apply changes of the stash to your working directory";
-			base.SubmitButtonTitle = "Apply";
+			base.DialogTitle = Translate("Apply Stash");
+		base.DialogDescription = Translate("Apply changes of the stash to your working directory");
+		base.SubmitButtonTitle = Translate("Apply");
 			DeleteStashAfterApplyCheckBox.IsChecked = ForkPlusSettings.Default.ApplyStash_DeleteAfterApply;
 		}
 

--- a/src/ForkPlus/UI/Dialogs/AskPassWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/AskPassWindow.xaml.cs
@@ -67,7 +67,7 @@ namespace ForkPlus.UI.Dialogs
 				InputPasswordBox.Show();
 				InputPasswordBox.Focus();
 			}
-			base.SubmitButtonTitle = "OK";
+			base.SubmitButtonTitle = PreferencesLocalization.Current("OK");
 		}
 
 		protected override void OnSubmit()

--- a/src/ForkPlus/UI/Dialogs/CheckoutAndSyncWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/CheckoutAndSyncWindow.xaml.cs
@@ -73,10 +73,10 @@ namespace ForkPlus.UI.Dialogs
 			};
 			CheckoutActionTypeComboBox.ItemsSource = _checkoutSyncOptionComboBoxItems;
 			CheckoutActionTypeComboBox.SelectedItem = IReadOnlyListExtensions.FirstItem(_checkoutSyncOptionComboBoxItems, (CheckoutSyncOptionComboBoxItem x) => x.ActionType == CheckoutActionType.None);
-			base.DialogTitle = "Checkout Branch";
-			base.DialogDescription = "Switch to '" + localBranch.Name + "' branch";
+			base.DialogTitle = PreferencesLocalization.Current("Checkout Branch");
+			base.DialogDescription = PreferencesLocalization.FormatCurrent("Switch to '{0}' branch", localBranch.Name);
 			GitPointView.Value = localBranch;
-			base.SubmitButtonTitle = "Checkout";
+			base.SubmitButtonTitle = PreferencesLocalization.Current("Checkout");
 		}
 
 		protected override void OnSubmit()
@@ -223,16 +223,16 @@ namespace ForkPlus.UI.Dialogs
 			switch (_actionType)
 			{
 			case CheckoutActionType.Rebase:
-				base.SubmitButtonTitle = "Checkout and Rebase";
+				base.SubmitButtonTitle = PreferencesLocalization.Current("Checkout and Rebase");
 				break;
 			case CheckoutActionType.Merge:
-				base.SubmitButtonTitle = "Checkout and Merge";
+				base.SubmitButtonTitle = PreferencesLocalization.Current("Checkout and Merge");
 				break;
 			case CheckoutActionType.Reset:
-				base.SubmitButtonTitle = "Checkout and Reset";
+				base.SubmitButtonTitle = PreferencesLocalization.Current("Checkout and Reset");
 				break;
 			default:
-				base.SubmitButtonTitle = "Checkout";
+				base.SubmitButtonTitle = PreferencesLocalization.Current("Checkout");
 				break;
 			}
 		}

--- a/src/ForkPlus/UI/Dialogs/CheckoutRevisionWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/CheckoutRevisionWindow.xaml.cs
@@ -26,9 +26,9 @@ namespace ForkPlus.UI.Dialogs
 		public CheckoutRevisionWindow(RepositoryUserControl repositoryUserControl, IGitPoint gitPoint, Sha gitPointSha)
 		{
 			InitializeComponent();
-			base.DialogTitle = "Checkout Commit";
-			base.DialogDescription = "Checkout a particular revision. Repository will be in detached HEAD state.";
-			base.SubmitButtonTitle = "Checkout Commit";
+			base.DialogTitle = Translate("Checkout Commit");
+			base.DialogDescription = Translate("Checkout a particular revision. Repository will be in detached HEAD state.");
+			base.SubmitButtonTitle = Translate("Checkout Commit");
 			_repositoryUserControl = repositoryUserControl;
 			_gitPoint = gitPoint;
 			_gitPointSha = gitPointSha;

--- a/src/ForkPlus/UI/Dialogs/CherryPickWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/CherryPickWindow.xaml.cs
@@ -46,8 +46,8 @@ namespace ForkPlus.UI.Dialogs
 			_revisions = revisions;
 			_firstRevisionParents = firstRevisionParents;
 			InitializeComponent();
-			base.DialogTitle = "Cherry Pick";
-			base.DialogDescription = "Apply changes of the individual commit";
+			base.DialogTitle = Translate("Cherry Pick");
+			base.DialogDescription = Translate("Apply changes of the individual commit");
 			AppendOriginShaCheckBox.IsChecked = ForkPlusSettings.Default.CherryPick_AppendOriginSha;
 			if (_revisions.SingleItem() != null)
 			{

--- a/src/ForkPlus/UI/Dialogs/CloneWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/CloneWindow.xaml.cs
@@ -108,9 +108,9 @@ namespace ForkPlus.UI.Dialogs
 		{
 			_account = account;
 			InitializeComponent();
-			base.DialogTitle = "Clone";
-			base.DialogDescription = "Clone a remote repository into a local folder";
-			base.SubmitButtonTitle = "Clone";
+			base.DialogTitle = Translate("Clone");
+			base.DialogDescription = Translate("Clone a remote repository into a local folder");
+			base.SubmitButtonTitle = Translate("Clone");
 			Refresh(url);
 			RefreshNetworkProtocolButton();
 			UpdateSubmitButton();

--- a/src/ForkPlus/UI/Dialogs/ConfigureSshKeysWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/ConfigureSshKeysWindow.xaml.cs
@@ -27,9 +27,9 @@ namespace ForkPlus.UI.Dialogs
 		{
 			base.ShowLogo = false;
 			InitializeComponent();
-			base.DialogTitle = "Configure SSH Keys";
-			base.DialogDescription = "1. Select or generate a new SSH key which will identify your computer\n2. Copy the public key content to the account section on the website of your git provider";
-			base.SubmitButtonTitle = "OK";
+			base.DialogTitle = Translate("Configure SSH Keys");
+			base.DialogDescription = Translate("1. Select or generate a new SSH key which will identify your computer\n2. Copy the public key content to the account section on the website of your git provider");
+			base.SubmitButtonTitle = Translate("OK");
 			Refresh();
 			SshKeyListBox.SelectedIndex = 0;
 		}

--- a/src/ForkPlus/UI/Dialogs/ConfigureWorkspacesWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/ConfigureWorkspacesWindow.xaml.cs
@@ -21,10 +21,10 @@ namespace ForkPlus.UI.Dialogs
 			Workspace[] all = ForkPlusSettings.Default.Workspaces.All;
 			_workspaceViewModels = new ObservableCollection<WorkspaceViewModel>(all.Map((Workspace x) => new WorkspaceViewModel(x)));
 			InitializeComponent();
-			base.DialogTitle = "Workspaces";
-			base.DialogDescription = "Use '/' as path separator to create folders";
+			base.DialogTitle = PreferencesLocalization.Current("Workspaces");
+			base.DialogDescription = PreferencesLocalization.Current("Use '/' as path separator to create folders");
 			base.ShowSubmitButton = false;
-			base.CancelButtonTitle = "Close";
+			base.CancelButtonTitle = PreferencesLocalization.Current("Close");
 			WorkspacesListBox.ItemsSource = _workspaceViewModels;
 			WorkspacesListBox.SelectedIndex = 0;
 			UpdateDeleteButtonState();

--- a/src/ForkPlus/UI/Dialogs/CreateBranchWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/CreateBranchWindow.xaml.cs
@@ -58,8 +58,8 @@ namespace ForkPlus.UI.Dialogs
 		public CreateBranchWindow(RepositoryUserControl repositoryUserControl, RepositoryReferences refs, IGitPoint gitPoint)
 		{
 			InitializeComponent();
-			base.DialogTitle = "Create Branch";
-			base.DialogDescription = "Use '/' as a path separator to create folders";
+			base.DialogTitle = Translate("Create Branch");
+			base.DialogDescription = Translate("Use '/' as a path separator to create folders");
 			_repositoryUserControl = repositoryUserControl;
 			_localBranches = refs.LocalBranches;
 			_gitPoint = gitPoint;

--- a/src/ForkPlus/UI/Dialogs/CreatePartialStashWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/CreatePartialStashWindow.xaml.cs
@@ -23,9 +23,9 @@ namespace ForkPlus.UI.Dialogs
 		public CreatePartialStashWindow(GitModule gitModule, ChangedFile[] filesToStash, ChangedFile[] allChangedFiles)
 		{
 			InitializeComponent();
-			base.DialogTitle = "Save stash";
-			base.DialogDescription = "Save your local modifications to a new stash. BOTH staged and unstaged changes will be stashed";
-			base.SubmitButtonTitle = "Save Stash";
+			base.DialogTitle = Translate("Save stash");
+			base.DialogDescription = Translate("Save your local modifications to a new stash. BOTH staged and unstaged changes will be stashed");
+			base.SubmitButtonTitle = Translate("Save Stash");
 			base.ResizeMode = ResizeMode.CanResizeWithGrip;
 			StashMessageTextBox.Placeholder = Translate("Stash message (optional)");
 			_gitModule = gitModule;

--- a/src/ForkPlus/UI/Dialogs/CustomActionResultWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/CustomActionResultWindow.xaml.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Markup;
+using ForkPlus.UI.UserControls.Preferences;
 
 namespace ForkPlus.UI.Dialogs
 {
@@ -13,9 +14,9 @@ namespace ForkPlus.UI.Dialogs
 		{
 			InitializeComponent();
 			base.DialogTitle = customActionName ?? "";
-			base.DialogDescription = customActionName + " completed";
+			base.DialogDescription = PreferencesLocalization.FormatCurrent("{0} completed", customActionName);
 			OutputTextBox.Text = output;
-			base.CancelButtonTitle = "Close";
+			base.CancelButtonTitle = PreferencesLocalization.Current("Close");
 			base.ShowSubmitButton = false;
 		}
 

--- a/src/ForkPlus/UI/Dialogs/DeleteWorktreeWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/DeleteWorktreeWindow.xaml.cs
@@ -22,9 +22,9 @@ namespace ForkPlus.UI.Dialogs
 			_repositoryUserControl = repositoryUserControl;
 			_worktree = worktree;
 			InitializeComponent();
-			base.DialogTitle = "Are you sure you want to delete worktree " + worktree.FriendlyName + "?";
-			base.DialogDescription = "Do you want to delete worktree " + worktree.Path + "?";
-			base.SubmitButtonTitle = "Delete";
+			base.DialogTitle = PreferencesLocalization.FormatCurrent("Are you sure you want to delete worktree {0}?", worktree.FriendlyName);
+			base.DialogDescription = PreferencesLocalization.FormatCurrent("Do you want to delete worktree {0}?", worktree.Path);
+			base.SubmitButtonTitle = PreferencesLocalization.Current("Delete");
 		}
 
 		protected override void OnSubmit()

--- a/src/ForkPlus/UI/Dialogs/EditRemoteWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/EditRemoteWindow.xaml.cs
@@ -398,9 +398,9 @@ namespace ForkPlus.UI.Dialogs
 		{
 			if (_remoteToEdit != null)
 			{
-				base.DialogTitle = "Edit Remote";
-				base.DialogDescription = "Edit URL of the remote repository";
-				base.SubmitButtonTitle = "Edit";
+				base.DialogTitle = PreferencesLocalization.Current("Edit Remote");
+				base.DialogDescription = PreferencesLocalization.Current("Edit URL of the remote repository");
+				base.SubmitButtonTitle = PreferencesLocalization.Current("Edit");
 				RepositoryUrlTextBox.Text = _remoteToEdit.Url;
 				RemoteNameTextBox.Text = _remoteToEdit.Name;
 				RemoteNameTextBox.Icon = _remoteToEdit.Icon;
@@ -408,9 +408,9 @@ namespace ForkPlus.UI.Dialogs
 				RefreshAccountsComboBox();
 				return;
 			}
-			base.DialogTitle = "Add Remote";
-			base.DialogDescription = "Add new remote repository reference";
-			base.SubmitButtonTitle = "Add New Remote";
+			base.DialogTitle = PreferencesLocalization.Current("Add Remote");
+			base.DialogDescription = PreferencesLocalization.Current("Add new remote repository reference");
+			base.SubmitButtonTitle = PreferencesLocalization.Current("Add New Remote");
 			RemoteNameTextBox.Icon = Theme.RemoteIcon;
 			RemoteNameTextBox.Text = Consts.Git.DefaultRemoteName;
 			string text = ServiceLocator.Clipboard.GetText();

--- a/src/ForkPlus/UI/Dialogs/ErrorWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/ErrorWindow.xaml.cs
@@ -29,9 +29,9 @@ namespace ForkPlus.UI.Dialogs
 		public ErrorWindow()
 		{
 			InitializeComponent();
-			base.DialogTitle = "Git Error";
-			base.DialogDescription = "An unexpected error occured while performing the git request";
-			base.CancelButtonTitle = "Close";
+			base.DialogTitle = Translate("Git Error");
+			base.DialogDescription = Translate("An unexpected error occured while performing the git request");
+			base.CancelButtonTitle = Translate("Close");
 			base.ShowSubmitButton = false;
 			base.ShowWarningIcon = true;
 			MessageEditor.Options.EnableHyperlinks = true;

--- a/src/ForkPlus/UI/Dialogs/FetchWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/FetchWindow.xaml.cs
@@ -39,9 +39,9 @@ namespace ForkPlus.UI.Dialogs
 			_gitModule = gitModule;
 			_predefinedRemote = remote;
 			InitializeComponent();
-			base.DialogTitle = "Fetch";
-			base.DialogDescription = "Fetch latest changes from remote repository";
-			base.SubmitButtonTitle = "Fetch";
+			base.DialogTitle = Translate("Fetch");
+		base.DialogDescription = Translate("Fetch latest changes from remote repository");
+		base.SubmitButtonTitle = Translate("Fetch");
 			Remote[] array = MainWindow.ActiveRepositoryUserControl.RepositoryData.Remotes.Items.ToSortedArray(Remote.ComparerIgnoreCaseNumeric);
 			RemoteComboBox.ItemsSource = array;
 			RemoteComboBox.SelectedItem = array.FirstOrDefault((Remote x) => x.Name == _predefinedRemote?.Name) ?? array.FirstOrDefault((Remote x) => x.Name == Consts.Git.DefaultRemoteName) ?? array.FirstOrDefault();

--- a/src/ForkPlus/UI/Dialogs/FileHistoryWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/FileHistoryWindow.xaml.cs
@@ -555,8 +555,8 @@ namespace ForkPlus.UI.Dialogs
 			if (historyEntries.Length > 2)
 			{
 				FallbackUserControl fallbackUserControl = new FallbackUserControl();
-				fallbackUserControl.FallbackTitle = "Select two commits to see difference between them";
-				fallbackUserControl.FallbackMessage = $"{historyEntries.Length} commits selected";
+				fallbackUserControl.FallbackTitle = Translate("Select two commits to see difference between them");
+				fallbackUserControl.FallbackMessage = string.Format(Translate("{0} commits selected"), historyEntries.Length);
 				FileDiffControl.ShowSubView(() => fallbackUserControl, delegate(FallbackUserControl c, FileControlHeaderUserControl h)
 				{
 					h.Collapse();
@@ -640,7 +640,7 @@ namespace ForkPlus.UI.Dialogs
 		private void ShowErrorFallback(string errorString)
 		{
 			CodeEditorFallbackUserControl.Show();
-			CodeEditorFallbackUserControl.FallbackTitle = "Error";
+			CodeEditorFallbackUserControl.FallbackTitle = Translate("Error");
 			CodeEditorFallbackUserControl.FallbackMessage = errorString;
 		}
 

--- a/src/ForkPlus/UI/Dialogs/GenerateNewSshKeyWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/GenerateNewSshKeyWindow.xaml.cs
@@ -55,9 +55,9 @@ namespace ForkPlus.UI.Dialogs
 		public GenerateNewSshKeyWindow()
 		{
 			InitializeComponent();
-			base.DialogTitle = "Generate new SSH Key";
-			base.DialogDescription = "Generate new ED25519 key";
-			base.SubmitButtonTitle = "Generate";
+			base.DialogTitle = Translate("Generate new SSH Key");
+			base.DialogDescription = Translate("Generate new ED25519 key");
+			base.SubmitButtonTitle = Translate("Generate");
 			_existingSshKeys = new GetLocalSshKeysCommand().Execute();
 		}
 

--- a/src/ForkPlus/UI/Dialogs/GitFlowFinishFeatureWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/GitFlowFinishFeatureWindow.xaml.cs
@@ -27,9 +27,9 @@ namespace ForkPlus.UI.Dialogs
 		public GitFlowFinishFeatureWindow(GitModule gitModule, RepositoryData repositoryData, LocalBranch featureBranch)
 		{
 			InitializeComponent();
-			base.DialogTitle = "Finish Git Flow feature";
-			base.DialogDescription = "Finish the feature and merge it into the develop branch";
-			base.SubmitButtonTitle = "Finish";
+			base.DialogTitle = PreferencesLocalization.Current("Finish Git Flow feature");
+			base.DialogDescription = PreferencesLocalization.Current("Finish the feature and merge it into the develop branch");
+			base.SubmitButtonTitle = PreferencesLocalization.Current("Finish");
 			_gitModule = gitModule;
 			_repositoryData = repositoryData;
 			_featureBranch = featureBranch;

--- a/src/ForkPlus/UI/Dialogs/GitFlowFinishHotfixWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/GitFlowFinishHotfixWindow.xaml.cs
@@ -28,9 +28,9 @@ namespace ForkPlus.UI.Dialogs
 		public GitFlowFinishHotfixWindow(GitModule gitModule, RepositoryData repositoryData, LocalBranch hotfixBranch)
 		{
 			InitializeComponent();
-			base.DialogTitle = "Finish Git Flow hotfix";
-			base.DialogDescription = "Finish the hotfix and merge it into the develop and master branches";
-			base.SubmitButtonTitle = "Finish";
+			base.DialogTitle = PreferencesLocalization.Current("Finish Git Flow hotfix");
+			base.DialogDescription = PreferencesLocalization.Current("Finish the hotfix and merge it into the develop and master branches");
+			base.SubmitButtonTitle = PreferencesLocalization.Current("Finish");
 			_gitModule = gitModule;
 			_repositoryData = repositoryData;
 			_hotfixBranch = hotfixBranch;

--- a/src/ForkPlus/UI/Dialogs/GitFlowFinishReleaseWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/GitFlowFinishReleaseWindow.xaml.cs
@@ -28,9 +28,9 @@ namespace ForkPlus.UI.Dialogs
 		public GitFlowFinishReleaseWindow(GitModule gitModule, RepositoryData repositoryData, LocalBranch releaseBranch)
 		{
 			InitializeComponent();
-			base.DialogTitle = "Finish Git Flow release";
-			base.DialogDescription = "Finish the release and merge it into the develop and master branches";
-			base.SubmitButtonTitle = "Finish";
+			base.DialogTitle = PreferencesLocalization.Current("Finish Git Flow release");
+			base.DialogDescription = PreferencesLocalization.Current("Finish the release and merge it into the develop and master branches");
+			base.SubmitButtonTitle = PreferencesLocalization.Current("Finish");
 			_gitModule = gitModule;
 			_repositoryData = repositoryData;
 			_releaseBranch = releaseBranch;

--- a/src/ForkPlus/UI/Dialogs/GitFlowStartFeatureWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/GitFlowStartFeatureWindow.xaml.cs
@@ -55,9 +55,9 @@ namespace ForkPlus.UI.Dialogs
 		public GitFlowStartFeatureWindow(GitModule gitModule)
 		{
 			InitializeComponent();
-			base.DialogTitle = "Start Git Flow feature";
-			base.DialogDescription = "Create a new feature branch based on 'develop' and switch to it";
-			base.SubmitButtonTitle = "Start Feature";
+			base.DialogTitle = PreferencesLocalization.Current("Start Git Flow feature");
+			base.DialogDescription = PreferencesLocalization.Current("Create a new feature branch based on 'develop' and switch to it");
+			base.SubmitButtonTitle = PreferencesLocalization.Current("Start Feature");
 			_gitModule = gitModule;
 			Refresh();
 		}

--- a/src/ForkPlus/UI/Dialogs/GitFlowStartHotfixWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/GitFlowStartHotfixWindow.xaml.cs
@@ -52,9 +52,9 @@ namespace ForkPlus.UI.Dialogs
 		public GitFlowStartHotfixWindow(GitModule gitModule)
 		{
 			InitializeComponent();
-			base.DialogTitle = "Start Git Flow hotfix";
-			base.DialogDescription = "Create a new hotfix branch based on 'master' and switch to it";
-			base.SubmitButtonTitle = "Start Hotfix";
+			base.DialogTitle = PreferencesLocalization.Current("Start Git Flow hotfix");
+			base.DialogDescription = PreferencesLocalization.Current("Create a new hotfix branch based on 'master' and switch to it");
+			base.SubmitButtonTitle = PreferencesLocalization.Current("Start Hotfix");
 			_gitModule = gitModule;
 			Refresh();
 		}

--- a/src/ForkPlus/UI/Dialogs/GitFlowStartReleaseWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/GitFlowStartReleaseWindow.xaml.cs
@@ -52,9 +52,9 @@ namespace ForkPlus.UI.Dialogs
 		public GitFlowStartReleaseWindow(GitModule gitModule)
 		{
 			InitializeComponent();
-			base.DialogTitle = "Start Git Flow release";
-			base.DialogDescription = "Create a new release branch based on 'develop' and switch to it";
-			base.SubmitButtonTitle = "Start Release";
+			base.DialogTitle = PreferencesLocalization.Current("Start Git Flow release");
+			base.DialogDescription = PreferencesLocalization.Current("Create a new release branch based on 'develop' and switch to it");
+			base.SubmitButtonTitle = PreferencesLocalization.Current("Start Release");
 			_gitModule = gitModule;
 			Refresh();
 		}

--- a/src/ForkPlus/UI/Dialogs/GitLfsFetchWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/GitLfsFetchWindow.xaml.cs
@@ -35,9 +35,9 @@ namespace ForkPlus.UI.Dialogs
 			_repositoryUserControl = repositoryUserControl;
 			_gitModule = gitModule;
 			InitializeComponent();
-			base.DialogTitle = "Fetch";
-			base.DialogDescription = "Download Git LFS objects from the specified remotes";
-			base.SubmitButtonTitle = "Fetch";
+			base.DialogTitle = Translate("Fetch");
+			base.DialogDescription = Translate("Download Git LFS objects from the specified remotes");
+			base.SubmitButtonTitle = Translate("Fetch");
 			Refresh();
 		}
 

--- a/src/ForkPlus/UI/Dialogs/GitLfsPullWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/GitLfsPullWindow.xaml.cs
@@ -33,9 +33,9 @@ namespace ForkPlus.UI.Dialogs
 		public GitLfsPullWindow(RepositoryUserControl repositoryUserControl, GitModule gitModule)
 		{
 			InitializeComponent();
-			base.DialogTitle = "Pull";
-			base.DialogDescription = "Download Git LFS objects for the currently checked out ref, and update the working directory with the downloaded content if required";
-			base.SubmitButtonTitle = "Pull";
+			base.DialogTitle = Translate("Pull");
+			base.DialogDescription = Translate("Download Git LFS objects for the currently checked out ref, and update the working directory with the downloaded content if required");
+			base.SubmitButtonTitle = Translate("Pull");
 			_repositoryUserControl = repositoryUserControl;
 			_gitModule = gitModule;
 			Refresh();

--- a/src/ForkPlus/UI/Dialogs/InteractiveRebaseWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/InteractiveRebaseWindow.xaml.cs
@@ -119,7 +119,7 @@ namespace ForkPlus.UI.Dialogs
 			VisualTreeAttachmentHelper.TrySetContent(base.Footer.CustomSection, _backupCurrentStateCheckBox, GetType().Name + ".Footer.CustomSection");
 			base.Footer.AlignStatusRight();
 			base.ShowCancelButton = true;
-			base.SubmitButtonTitle = "Rebase";
+			base.SubmitButtonTitle = Translate("Rebase");
 			SourceGitPointView.Value = _sourceBranch;
 			DestinationGitPointView.Value = _destination;
 			InteractiveRebaseComboBoxItemsSource = InteractiveRebaseComboBoxItems;
@@ -127,7 +127,7 @@ namespace ForkPlus.UI.Dialogs
 			RevisionListView.DataContext = this;
 			RevisionDetails.Initialize(repositoryUserControl, RevisionDetailsUserControlMode.InteractiveRebase);
 			RevisionListFallbackUserControl.Show();
-			RevisionListFallbackUserControl.FallbackMessage = "Loading...";
+			RevisionListFallbackUserControl.FallbackMessage = Translate("Loading...");
 			SetStatus(ForkPlusDialogStatus.InProgress, "");
 			_refreshRevisionDetails = new DelayedAction<string>(delegate(string shaString)
 			{

--- a/src/ForkPlus/UI/Dialogs/KeyboardShortcutsWindow.cs
+++ b/src/ForkPlus/UI/Dialogs/KeyboardShortcutsWindow.cs
@@ -114,9 +114,9 @@ namespace ForkPlus.UI.Dialogs
 
 		private void ApplyDialogChrome()
 		{
-			base.DialogTitle = "Keyboard Shortcuts";
-			base.DialogDescription = "Available keyboard shortcuts";
-			base.SubmitButtonTitle = "Close";
+			base.DialogTitle = Translate("Keyboard Shortcuts");
+			base.DialogDescription = Translate("Available keyboard shortcuts");
+			base.SubmitButtonTitle = Translate("Close");
 			base.ShowCancelButton = false;
 		}
 

--- a/src/ForkPlus/UI/Dialogs/LeanBranchingStartWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/LeanBranchingStartWindow.xaml.cs
@@ -56,8 +56,8 @@ namespace ForkPlus.UI.Dialogs
 		public LeanBranchingStartWindow(RepositoryUserControl repositoryUserControl, Branch mainBranch)
 		{
 			InitializeComponent();
-			base.DialogTitle = "Start Branch";
-			base.DialogDescription = "Use '/' as a path separator to create folders";
+			base.DialogTitle = Translate("Start Branch");
+			base.DialogDescription = Translate("Use '/' as a path separator to create folders");
 			_repositoryUserControl = repositoryUserControl;
 			_repositoryReferences = repositoryUserControl.RepositoryData.References;
 			_localBranches = _repositoryReferences.LocalBranches;

--- a/src/ForkPlus/UI/Dialogs/MergeBranchWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/MergeBranchWindow.xaml.cs
@@ -72,9 +72,9 @@ namespace ForkPlus.UI.Dialogs
 			_source = source;
 			_destination = destination;
 			InitializeComponent();
-			base.DialogTitle = "Merge Branch";
-			base.DialogDescription = "Merge branch into another one";
-			base.SubmitButtonTitle = "Merge";
+			base.DialogTitle = PreferencesLocalization.Current("Merge Branch");
+			base.DialogDescription = PreferencesLocalization.Current("Merge branch into another one");
+			base.SubmitButtonTitle = PreferencesLocalization.Current("Merge");
 			SourceGitPointView.Value = source;
 			DestinationGitPointView.Value = destination;
 			MergeTypeComboBox.ItemsSource = _mergeOptionsComboBoxItems;

--- a/src/ForkPlus/UI/Dialogs/OpenRepositoryAlertWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/OpenRepositoryAlertWindow.xaml.cs
@@ -15,11 +15,11 @@ namespace ForkPlus.UI.Dialogs
 			InitializeComponent();
 			base.DescriptionTextBlock.TextTrimming = TextTrimming.CharacterEllipsis;
 			base.DescriptionTextBlock.MaxHeight = 80.0;
-			base.DialogTitle = "The directory is not under git source control";
-			base.DialogDescription = "The '" + repositoryDirectory + "' directory is not a git repository";
+			base.DialogTitle = PreferencesLocalization.Current("The directory is not under git source control");
+			base.DialogDescription = PreferencesLocalization.FormatCurrent("The '{0}' directory is not a git repository", repositoryDirectory);
 			base.ShowSubmitButton = false;
 			FirstButton.Content = PreferencesLocalization.Current("Initialize git repository here");
-			base.CancelButtonTitle = "Close";
+			base.CancelButtonTitle = PreferencesLocalization.Current("Close");
 			base.Footer.SubmitButton.IsDefault = false;
 			base.Footer.CancelButton.IsDefault = true;
 			base.Dispatcher.Async(delegate

--- a/src/ForkPlus/UI/Dialogs/PreferencesWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/PreferencesWindow.xaml.cs
@@ -23,7 +23,7 @@ namespace ForkPlus.UI.Dialogs
 			base.ShowLogo = false;
 			InitializeComponent();
 			base.ShowCancelButton = false;
-			base.SubmitButtonTitle = "Close";
+			base.SubmitButtonTitle = PreferencesLocalization.Current("Close");
 			base.SizeToContent = SizeToContent.WidthAndHeight;
 			Initialize();
 		}

--- a/src/ForkPlus/UI/Dialogs/PullWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/PullWindow.xaml.cs
@@ -59,9 +59,9 @@ namespace ForkPlus.UI.Dialogs
 				_repositoryUserControl = repositoryUserControl;
 				_predefinedRemoteBranch = remoteBranch;
 				InitializeComponent();
-				base.DialogTitle = "Pull";
-				base.DialogDescription = "Pull remote branches and merge them into your local branch";
-				base.SubmitButtonTitle = "Pull";
+				base.DialogTitle = Translate("Pull");
+				base.DialogDescription = Translate("Pull remote branches and merge them into your local branch");
+				base.SubmitButtonTitle = Translate("Pull");
 				RebaseCheckBox.IsChecked = ForkPlusSettings.Default.Pull_Rebase;
 				StashAndReapplyCheckBox.IsChecked = ForkPlusSettings.Default.Pull_StashAndReapply;
 				LoadReferencesAndRefresh(repositoryData.Remotes.Items, repositoryData.References.RemoteBranches, repositoryData.References.ActiveBranch);

--- a/src/ForkPlus/UI/Dialogs/PushMultipleBranchesWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/PushMultipleBranchesWindow.xaml.cs
@@ -43,7 +43,7 @@ namespace ForkPlus.UI.Dialogs
 			_localBranches = localBranches;
 			_remote = remote;
 			InitializeComponent();
-			base.DialogTitle = "Push";
+			base.DialogTitle = Translate("Push");
 			base.DialogDescription = string.Format(Translate("Push {0} branches to remote repository"), _localBranches.Length);
 			base.SubmitButtonTitle = string.Format(Translate("Push {0} branches"), _localBranches.Length);
 			Refresh();

--- a/src/ForkPlus/UI/Dialogs/PushMultipleTagsWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/PushMultipleTagsWindow.xaml.cs
@@ -39,7 +39,7 @@ namespace ForkPlus.UI.Dialogs
 			_tags = tags;
 			_remoteToSelect = remote;
 			InitializeComponent();
-			base.DialogTitle = "Push";
+			base.DialogTitle = Translate("Push");
 			base.DialogDescription = string.Format(Translate("Push {0} tags to remote repository"), _tags.Length);
 			base.SubmitButtonTitle = string.Format(Translate("Push {0} tags"), _tags.Length);
 			Refresh();

--- a/src/ForkPlus/UI/Dialogs/PushTagWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/PushTagWindow.xaml.cs
@@ -40,9 +40,9 @@ namespace ForkPlus.UI.Dialogs
 			_remoteToSelect = remote;
 			_tag = tag;
 			InitializeComponent();
-			base.DialogTitle = "Push Tag";
-			base.DialogDescription = "Push tag to remote repository";
-			base.SubmitButtonTitle = "Push";
+			base.DialogTitle = Translate("Push Tag");
+			base.DialogDescription = Translate("Push tag to remote repository");
+			base.SubmitButtonTitle = Translate("Push");
 			Refresh();
 			UpdateSubmitButton();
 		}

--- a/src/ForkPlus/UI/Dialogs/PushWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/PushWindow.xaml.cs
@@ -162,9 +162,9 @@ namespace ForkPlus.UI.Dialogs
 			_localBranchToSelect = localBranch;
 			_customRefspec = null;
 			InitializeComponent();
-			base.DialogTitle = "Push";
-			base.DialogDescription = "Push your local changes to remote repository";
-			base.SubmitButtonTitle = "Push";
+			base.DialogTitle = Translate("Push");
+			base.DialogDescription = Translate("Push your local changes to remote repository");
+			base.SubmitButtonTitle = Translate("Push");
 			AllTagsCheckBox.IsChecked = ForkPlusSettings.Default.Push_PushAllTags;
 			ForcePushWarningImage.ToolTip = Translate("Overwrite the remote branch even if it's not an ancestor of the local branch.\n- Force push is required for rebase of already published branch.\n- Blindly using force push can be dangerous as you can overwrite other users' commits.\n- Fork always uses --force-with-lease which protects from race conditions.");
 			Refresh();

--- a/src/ForkPlus/UI/Dialogs/RebaseBranchWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/RebaseBranchWindow.xaml.cs
@@ -28,9 +28,9 @@ namespace ForkPlus.UI.Dialogs
 		{
 			RebaseBranchWindow rebaseBranchWindow = this;
 			InitializeComponent();
-			base.DialogTitle = "Rebase";
-			base.DialogDescription = "Copy commits from one branch to another";
-			base.SubmitButtonTitle = "Rebase";
+			base.DialogTitle = PreferencesLocalization.Current("Rebase");
+			base.DialogDescription = PreferencesLocalization.Current("Copy commits from one branch to another");
+			base.SubmitButtonTitle = PreferencesLocalization.Current("Rebase");
 			_repositoryUserControl = repositoryUserControl;
 			_source = source;
 			_destination = destination;

--- a/src/ForkPlus/UI/Dialogs/RemoveLocalBranchWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/RemoveLocalBranchWindow.xaml.cs
@@ -92,10 +92,10 @@ namespace ForkPlus.UI.Dialogs
 			if (_branchesToRemove.Length == 1)
 			{
 				base.SizeToContent = SizeToContent.Height;
-				base.DialogTitle = "Delete Branch";
-				base.DialogDescription = "Delete local branch from your repository";
+				base.DialogTitle = Translate("Delete Branch");
+				base.DialogDescription = Translate("Delete local branch from your repository");
 				StartPointTextBlock.Text = Translate("Branch:");
-				base.SubmitButtonTitle = "Delete";
+				base.SubmitButtonTitle = Translate("Delete");
 				LocalBranch localBranch = branchesToRemove.FirstItem();
 				BranchesContainer.Collapse();
 				GitPointView.Show();
@@ -132,11 +132,11 @@ namespace ForkPlus.UI.Dialogs
 				base.Height = 270.0;
 				base.MinHeight = 270.0;
 				base.ResizeMode = ResizeMode.CanResizeWithGrip;
-				base.DialogTitle = "Delete Branches";
-				base.DialogDescription = "Delete local branches from your repository";
+				base.DialogTitle = Translate("Delete Branches");
+				base.DialogDescription = Translate("Delete local branches from your repository");
 				StartPointTextBlock.Text = Translate("Branches:");
 				DeleteRemoteBranchCheckBox.Content = Translate("Also delete corresponding remote branches");
-				base.SubmitButtonTitle = $"Delete {_branchesToRemove.Length} branches";
+				base.SubmitButtonTitle = PreferencesLocalization.FormatCurrent("Delete {0} branches", _branchesToRemove.Length);
 				GitPointView.Collapse();
 				DeleteRemoteBranchCheckBox.IsEnabled = AtLeastOneBranchHasUpstream(_branchesToRemove, _remoteBranches);
 				BranchesContainer.Show();

--- a/src/ForkPlus/UI/Dialogs/RemoveRemoteBranchWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/RemoveRemoteBranchWindow.xaml.cs
@@ -34,20 +34,20 @@ namespace ForkPlus.UI.Dialogs
 				GitPointsContainer.Collapse();
 				GitPointView.Show();
 				GitPointView.Value = remoteBranches.FirstItem();
-				base.DialogTitle = "Delete Branch";
-				base.DialogDescription = "Delete branch from remote repository";
+				base.DialogTitle = PreferencesLocalization.Current("Delete Branch");
+				base.DialogDescription = PreferencesLocalization.Current("Delete branch from remote repository");
 				StartPointTextBlock.Text = PreferencesLocalization.Current("Branch:");
-				base.SubmitButtonTitle = "Delete";
+				base.SubmitButtonTitle = PreferencesLocalization.Current("Delete");
 			}
 			else
 			{
 				GitPointView.Collapse();
 				GitPointsContainer.Show();
 				GitPoints.ItemsSource = _remoteBranches;
-				base.DialogTitle = "Delete Branches";
-				base.DialogDescription = "Delete branches from remote repository";
+				base.DialogTitle = PreferencesLocalization.Current("Delete Branches");
+				base.DialogDescription = PreferencesLocalization.Current("Delete branches from remote repository");
 				StartPointTextBlock.Text = PreferencesLocalization.Current("Branches:");
-				base.SubmitButtonTitle = $"Delete {remoteBranches.Length} branches";
+				base.SubmitButtonTitle = PreferencesLocalization.FormatCurrent("Delete {0} branches", remoteBranches.Length);
 			}
 		}
 

--- a/src/ForkPlus/UI/Dialogs/RemoveStashWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/RemoveStashWindow.xaml.cs
@@ -29,18 +29,18 @@ namespace ForkPlus.UI.Dialogs
 				GitPointsContainer.Collapse();
 				GitPointView.Show();
 				GitPointView.Value = _stashes.FirstItem();
-				base.DialogTitle = "Delete Stash";
-				base.DialogDescription = "Delete stash from your repository";
+				base.DialogTitle = Translate("Delete Stash");
+				base.DialogDescription = Translate("Delete stash from your repository");
 				StartPointTextBlock.Text = Translate("Stash:");
-				base.SubmitButtonTitle = "Delete";
+				base.SubmitButtonTitle = Translate("Delete");
 			}
 			else
 			{
 				GitPointView.Collapse();
 				GitPointsContainer.Show();
 				GitPoints.ItemsSource = _stashes;
-				base.DialogTitle = "Delete Stashes";
-				base.DialogDescription = "Delete stashes from your repository";
+				base.DialogTitle = Translate("Delete Stashes");
+				base.DialogDescription = Translate("Delete stashes from your repository");
 				StartPointTextBlock.Text = Translate("Stashes:");
 				base.SubmitButtonTitle = string.Format(Translate("Delete {0} stashes"), _stashes.Length);
 			}

--- a/src/ForkPlus/UI/Dialogs/RemoveTagWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/RemoveTagWindow.xaml.cs
@@ -34,22 +34,22 @@ namespace ForkPlus.UI.Dialogs
 				GitPointsContainer.Collapse();
 				GitPointView.Show();
 				GitPointView.Value = _tags.FirstItem();
-				base.DialogTitle = "Delete Tag";
-				base.DialogDescription = "Delete tag from your repository";
+				base.DialogTitle = PreferencesLocalization.Current("Delete Tag");
+				base.DialogDescription = PreferencesLocalization.Current("Delete tag from your repository");
 				StartPointTextBlock.Text = PreferencesLocalization.Current("Tag:");
 				DeleteFromRemotesCheckBox.Content = PreferencesLocalization.Current("Delete tag from remote repositories");
-				base.SubmitButtonTitle = "Delete";
+				base.SubmitButtonTitle = PreferencesLocalization.Current("Delete");
 			}
 			else
 			{
 				GitPointView.Collapse();
 				GitPointsContainer.Show();
 				GitPoints.ItemsSource = _tags;
-				base.DialogTitle = "Delete Tags";
-				base.DialogDescription = "Delete tags from your repository";
+				base.DialogTitle = PreferencesLocalization.Current("Delete Tags");
+				base.DialogDescription = PreferencesLocalization.Current("Delete tags from your repository");
 				StartPointTextBlock.Text = PreferencesLocalization.Current("Tags:");
 				DeleteFromRemotesCheckBox.Content = PreferencesLocalization.Current("Delete tags from remote repositories");
-				base.SubmitButtonTitle = $"Delete {_tags.Length} tags";
+				base.SubmitButtonTitle = PreferencesLocalization.FormatCurrent("Delete {0} tags", _tags.Length);
 			}
 		}
 

--- a/src/ForkPlus/UI/Dialogs/RepositorySettingsWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/RepositorySettingsWindow.xaml.cs
@@ -22,7 +22,7 @@ namespace ForkPlus.UI.Dialogs
 			base.ShowLogo = false;
 			InitializeComponent();
 			base.ShowCancelButton = false;
-			base.SubmitButtonTitle = "Close";
+			base.SubmitButtonTitle = PreferencesLocalization.Current("Close");
 			base.SizeToContent = SizeToContent.WidthAndHeight;
 			Initialize();
 		}

--- a/src/ForkPlus/UI/Dialogs/RescanRepositoriesWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/RescanRepositoriesWindow.xaml.cs
@@ -6,6 +6,7 @@ using System.Windows.Controls;
 using System.Windows.Markup;
 using ForkPlus.Settings;
 using ForkPlus.UI.Commands;
+using ForkPlus.UI.UserControls.Preferences;
 
 namespace ForkPlus.UI.Dialogs
 {
@@ -16,10 +17,10 @@ namespace ForkPlus.UI.Dialogs
 		public RescanRepositoriesWindow()
 		{
 			InitializeComponent();
-			base.DialogTitle = "Rescan repositories in source folder";
+			base.DialogTitle = PreferencesLocalization.Current("Rescan repositories in source folder");
 			string text = RepositoryManager.Instance.SourceDirs.Map((string x) => "'" + x + "'").Joined(", ");
-			base.DialogDescription = "Do you want to rescan repositories in '" + text + "'?";
-			base.SubmitButtonTitle = "Rescan";
+			base.DialogDescription = PreferencesLocalization.FormatCurrent("Do you want to rescan repositories in '{0}'?", text);
+			base.SubmitButtonTitle = PreferencesLocalization.Current("Rescan");
 			ResetDeletedCheckbox.IsChecked = false;
 		}
 

--- a/src/ForkPlus/UI/Dialogs/ResetBranchWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/ResetBranchWindow.xaml.cs
@@ -31,18 +31,18 @@ namespace ForkPlus.UI.Dialogs
 			_branch = activeBranch;
 			_destination = destination;
 			if (activeBranch != null)
-			{
-				base.DialogTitle = "Reset Current Branch to Revision";
-				base.DialogDescription = "Move the '" + activeBranch.Name + "' branch HEAD to the selected revision";
-				ActiveBranchGitPointView.Value = activeBranch;
-			}
-			else
-			{
-				base.DialogTitle = "Reset HEAD to Revision";
-				base.DialogDescription = "Move HEAD to the selected revision";
-				ActiveBranchGitPointView.Value = new SymbolicReference("HEAD");
-			}
-			base.SubmitButtonTitle = "Reset";
+		{
+			base.DialogTitle = PreferencesLocalization.Current("Reset Current Branch to Revision");
+			base.DialogDescription = PreferencesLocalization.FormatCurrent("Move the '{0}' branch HEAD to the selected revision", activeBranch.Name);
+			ActiveBranchGitPointView.Value = activeBranch;
+		}
+		else
+		{
+			base.DialogTitle = PreferencesLocalization.Current("Reset HEAD to Revision");
+			base.DialogDescription = PreferencesLocalization.Current("Move HEAD to the selected revision");
+			ActiveBranchGitPointView.Value = new SymbolicReference("HEAD");
+		}
+		base.SubmitButtonTitle = PreferencesLocalization.Current("Reset");
 			DestinationGitPointView.Value = _destination;
 		}
 

--- a/src/ForkPlus/UI/Dialogs/RevertRevisionWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/RevertRevisionWindow.xaml.cs
@@ -46,9 +46,9 @@ namespace ForkPlus.UI.Dialogs
 			_revision = revision;
 			_revisionParents = revisionParents;
 			InitializeComponent();
-			base.DialogTitle = "Revert";
-			base.DialogDescription = "Revert changes of the individual commit";
-			base.SubmitButtonTitle = "Revert";
+			base.DialogTitle = Translate("Revert");
+			base.DialogDescription = Translate("Revert changes of the individual commit");
+			base.SubmitButtonTitle = Translate("Revert");
 			RevisionGitPointView.Value = revision;
 			CommitCheckBox.IsChecked = true;
 			if (MergeRevision)

--- a/src/ForkPlus/UI/Dialogs/RunSharedCustomCommandConfirmationWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/RunSharedCustomCommandConfirmationWindow.xaml.cs
@@ -21,10 +21,10 @@ namespace ForkPlus.UI.Dialogs
 			base.DescriptionTextBlock.TextTrimming = TextTrimming.CharacterEllipsis;
 			base.DescriptionTextBlock.TextWrapping = TextWrapping.Wrap;
 			base.DescriptionTextBlock.MaxHeight = 80.0;
-			base.DialogTitle = "The custom command has come from the '" + repositoryName + "' repository";
-			base.DialogDescription = "You should only run custom commands from trustworthy repositories. Do you really want to run it?";
-			base.SubmitButtonTitle = "Run";
-			base.CancelButtonTitle = "Cancel";
+			base.DialogTitle = PreferencesLocalization.FormatCurrent("The custom command has come from the '{0}' repository", repositoryName);
+			base.DialogDescription = PreferencesLocalization.Current("You should only run custom commands from trustworthy repositories. Do you really want to run it?");
+			base.SubmitButtonTitle = PreferencesLocalization.Current("Run");
+			base.CancelButtonTitle = PreferencesLocalization.Current("Cancel");
 			base.ShowCancelButton = true;
 			base.Width = 600.0;
 			base.ShowWarningIcon = true;

--- a/src/ForkPlus/UI/Dialogs/SaveAsPatchWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/SaveAsPatchWindow.xaml.cs
@@ -34,9 +34,9 @@ namespace ForkPlus.UI.Dialogs
 			_src = revision.Sha;
 			_dst = dst;
 			InitializeComponent();
-			base.DialogTitle = "Create Patch";
-			base.DialogDescription = "Save commit as patch";
-			base.SubmitButtonTitle = "Save";
+			base.DialogTitle = Translate("Create Patch");
+			base.DialogDescription = Translate("Save commit as patch");
+			base.SubmitButtonTitle = Translate("Save");
 			RevisionsTextBlock.Text = Translate(dst.HasValue ? "Revisions:" : "Revision:");
 		}
 

--- a/src/ForkPlus/UI/Dialogs/SaveSnapshotWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/SaveSnapshotWindow.xaml.cs
@@ -20,9 +20,9 @@ namespace ForkPlus.UI.Dialogs
 		public SaveSnapshotWindow(RepositoryUserControl repositoryUserControl)
 		{
 			InitializeComponent();
-			base.DialogTitle = "Save snapshot";
-			base.DialogDescription = "Save your local changes to a new stash, but keep them in the working directory";
-			base.SubmitButtonTitle = "Save Snapshot";
+			base.DialogTitle = Translate("Save snapshot");
+			base.DialogDescription = Translate("Save your local changes to a new stash, but keep them in the working directory");
+			base.SubmitButtonTitle = Translate("Save Snapshot");
 			_repositoryUserControl = repositoryUserControl;
 			StashMessageTextBox.Placeholder = Translate("Stash message (optional)");
 			StageNewFilesCheckBox.IsChecked = ForkPlusSettings.Default.SaveStash_StageNewFiles;

--- a/src/ForkPlus/UI/Dialogs/SaveStashWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/SaveStashWindow.xaml.cs
@@ -19,9 +19,9 @@ namespace ForkPlus.UI.Dialogs
 		public SaveStashWindow(GitModule gitModule)
 		{
 			InitializeComponent();
-			base.DialogTitle = "Save stash";
-			base.DialogDescription = "Save your local changes to a new stash";
-			base.SubmitButtonTitle = "Save Stash";
+			base.DialogTitle = Translate("Save stash");
+			base.DialogDescription = Translate("Save your local changes to a new stash");
+			base.SubmitButtonTitle = Translate("Save Stash");
 			_gitModule = gitModule;
 			StashMessageTextBox.Placeholder = Translate("Stash message (optional)");
 			StageNewFilesCheckBox.IsChecked = ForkPlusSettings.Default.SaveStash_StageNewFiles;

--- a/src/ForkPlus/UI/Dialogs/SideBySideMergeWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/SideBySideMergeWindow.xaml.cs
@@ -95,7 +95,7 @@ namespace ForkPlus.UI.Dialogs
 			base.ShowHeader = false;
 			base.ShowLogo = false;
 			InitializeComponent();
-			base.SubmitButtonTitle = "Resolve";
+			base.SubmitButtonTitle = PreferencesLocalization.Current("Resolve");
 			FileMergeControl.RepositoryUserControl = repositoryUserControl;
 			LocalMergeEditor.ViewMode = MergeConflictPart.Local;
 			RemoteMergeEditor.ViewMode = MergeConflictPart.Remote;

--- a/src/ForkPlus/UI/Dialogs/TagDetailsWindow.xaml.cs
+++ b/src/ForkPlus/UI/Dialogs/TagDetailsWindow.xaml.cs
@@ -6,6 +6,7 @@ using System.Windows.Markup;
 using ForkPlus.Git;
 using ForkPlus.Git.Commands;
 using ForkPlus.UI.Controls;
+using ForkPlus.UI.UserControls.Preferences;
 
 namespace ForkPlus.UI.Dialogs
 {
@@ -15,10 +16,10 @@ namespace ForkPlus.UI.Dialogs
 		public TagDetailsWindow(GitModule gitModule, Tag tag)
 		{
 			InitializeComponent();
-			base.DialogTitle = "Tag Details";
+			base.DialogTitle = PreferencesLocalization.Current("Tag Details");
 			base.DialogDescription = "";
 			base.ShowSubmitButton = false;
-			base.CancelButtonTitle = "Close";
+			base.CancelButtonTitle = PreferencesLocalization.Current("Close");
 			GitPointView.Value = tag;
 			GitCommandResult<AnnotatedTagDetails> gitCommandResult = new GetTagMessageGitCommand().Execute(gitModule, tag.TargetObjectSha.Value);
 			if (gitCommandResult.Succeeded)

--- a/src/ForkPlus/UI/MainWindow.xaml.cs
+++ b/src/ForkPlus/UI/MainWindow.xaml.cs
@@ -465,14 +465,31 @@ namespace ForkPlus.UI
 				Log.Info("Application Window Activated");
 				if (!RefreshActiveCommitViewStatus())
 				{
-					TabControl.SelectedTab?.Refresh();
-					RefreshRepositoriesStatus();
+					RepositoryUserControl activeRepositoryUserControl = TabManager.ActiveRepositoryUserControl;
+					string repositoryPath = activeRepositoryUserControl?.GitModule?.Path ?? "";
+					if (!ShouldSkipActivationRefresh(repositoryPath))
+					{
+						TabControl.SelectedTab?.Refresh();
+						RefreshRepositoriesStatus();
+					}
 				}
 			}
 			if (ShowNewYearNotification.NotificationRequired)
 			{
 				new ShowNewYearNotification().Execute();
 			}
+		}
+
+		private bool ShouldSkipActivationRefresh(string repositoryPath)
+		{
+			DateTime now = DateTime.UtcNow;
+			if (string.Equals(repositoryPath, _lastActivationStatusRefreshRepositoryPath, StringComparison.OrdinalIgnoreCase) && now - _lastActivationStatusRefreshTime < TimeSpan.FromSeconds(10.0))
+			{
+				return true;
+			}
+			_lastActivationStatusRefreshRepositoryPath = repositoryPath;
+			_lastActivationStatusRefreshTime = now;
+			return false;
 		}
 
 		private bool RefreshActiveCommitViewStatus()
@@ -483,13 +500,10 @@ namespace ForkPlus.UI
 				return false;
 			}
 			string repositoryPath = activeRepositoryUserControl.GitModule?.Path ?? "";
-			DateTime now = DateTime.UtcNow;
-			if (string.Equals(repositoryPath, _lastActivationStatusRefreshRepositoryPath, StringComparison.OrdinalIgnoreCase) && now - _lastActivationStatusRefreshTime < TimeSpan.FromSeconds(5.0))
+			if (ShouldSkipActivationRefresh(repositoryPath))
 			{
 				return true;
 			}
-			_lastActivationStatusRefreshRepositoryPath = repositoryPath;
-			_lastActivationStatusRefreshTime = now;
 			activeRepositoryUserControl.InvalidateAndRefresh(SubDomain.Status, null, RepositoryViewMode.CommitViewMode);
 			return true;
 		}

--- a/src/ForkPlus/UI/UserControls/CommitUserControl.xaml.cs
+++ b/src/ForkPlus/UI/UserControls/CommitUserControl.xaml.cs
@@ -2048,11 +2048,16 @@ namespace ForkPlus.UI.UserControls
 							{
 								new ErrorWindow(RepositoryUserControl, patchResult.Error).ShowDialog();
 							});
+							return;
 						}
 						OpenAiService openAiService = OpenAiService.CreateFromAiReviewSettings();
 						ServiceResult<OpenAiResponse> response = openAiService.GenerateCommitMessage(patchResult.Result, GitModule, monitor);
 						base.Dispatcher.Async(delegate
 						{
+							if (monitor.IsCanceled)
+							{
+								return;
+							}
 							if (!response.Succeeded)
 							{
 								new ErrorWindow(response.Error.FriendlyMessage).ShowDialog();

--- a/src/ForkPlus/UI/UserControls/GitMmUserControl.xaml.cs
+++ b/src/ForkPlus/UI/UserControls/GitMmUserControl.xaml.cs
@@ -31,7 +31,15 @@ namespace ForkPlus.UI.UserControls
 
 		private const double SubrepoTabMinWidth = 140.0;
 
-		private static readonly TimeSpan RuntimeStateCacheTtl = TimeSpan.FromSeconds(10.0);
+		private static readonly TimeSpan RuntimeStateCacheTtl = TimeSpan.FromSeconds(60.0);
+
+		private static readonly TimeSpan DefaultBranchCacheTtl = TimeSpan.FromMinutes(30.0);
+
+		private static readonly Dictionary<string, Tuple<string, DateTime>> _defaultBranchCache = new Dictionary<string, Tuple<string, DateTime>>(StringComparer.OrdinalIgnoreCase);
+
+		private readonly DelayedAction<object> _saveSettingsAction;
+
+		private readonly DelayedAction<object> _updateTabWidthsAction;
 
 		private readonly JobQueue _jobQueue = new JobQueue();
 
@@ -121,9 +129,11 @@ namespace ForkPlus.UI.UserControls
 			WeakEventManager<NotificationCenter, EventArgs<string>>.AddHandler(NotificationCenter.Current, "RepositoryNameChanged", RepositoryNameChanged);
 			WeakEventManager<NotificationCenter, EventArgs<RepositoryManager.Repository>>.AddHandler(NotificationCenter.Current, "RepositoryColorChanged", RepositoryColorChanged);
 			SubreposTabControl.SelectionChanged += SubreposTabControl_SelectionChanged;
+			_saveSettingsAction = new DelayedAction<object>(delegate { SaveSettingsImmediate(); }, 1.0);
+			_updateTabWidthsAction = new DelayedAction<object>(delegate { UpdateSubrepoTabWidths(); }, 0.1);
 			SubreposTabControl.SizeChanged += delegate
 			{
-				UpdateSubrepoTabWidths();
+				_updateTabWidthsAction.InvokeWithDelay(null);
 			};
 			PreferencesLocalization.Apply(this, ForkPlusSettings.Default.UiLanguage);
 			RefreshCommandButtonTooltips();
@@ -856,6 +866,15 @@ namespace ForkPlus.UI.UserControls
 		}
 
 		private void SaveSettings()
+		{
+			if (_restoringSettings)
+			{
+				return;
+			}
+			_saveSettingsAction.InvokeWithDelay(null);
+		}
+
+		private void SaveSettingsImmediate()
 		{
 			if (_restoringSettings)
 			{
@@ -1864,6 +1883,15 @@ namespace ForkPlus.UI.UserControls
 
 		private static string GetDefaultBranch(string path, JobMonitor monitor = null)
 		{
+			string normalizedPath = NormalizePath(path);
+			if (normalizedPath != null && _defaultBranchCache.TryGetValue(normalizedPath, out Tuple<string, DateTime> cached))
+			{
+				if (DateTime.UtcNow - cached.Item2 < DefaultBranchCacheTtl)
+				{
+					return cached.Item1;
+				}
+				_defaultBranchCache.Remove(normalizedPath);
+			}
 			GitRequestResult result = RunGit(path, new GitCommand("symbolic-ref", "--short", "refs/remotes/origin/HEAD"), monitor);
 			if (result.Success)
 			{
@@ -1871,10 +1899,14 @@ namespace ForkPlus.UI.UserControls
 				const string originPrefix = "origin/";
 				if (value.StartsWith(originPrefix, StringComparison.OrdinalIgnoreCase))
 				{
-					return value.Substring(originPrefix.Length);
+					value = value.Substring(originPrefix.Length);
 				}
 				if (!string.IsNullOrWhiteSpace(value))
 				{
+					if (normalizedPath != null)
+					{
+						_defaultBranchCache[normalizedPath] = Tuple.Create(value, DateTime.UtcNow);
+					}
 					return value;
 				}
 			}

--- a/src/ForkPlus/UI/UserControls/Preferences/AiReviewPreferencesUserControl.xaml.cs
+++ b/src/ForkPlus/UI/UserControls/Preferences/AiReviewPreferencesUserControl.xaml.cs
@@ -154,8 +154,8 @@ namespace ForkPlus.UI.UserControls.Preferences
 		{
 		 Microsoft.Win32.OpenFileDialog dialog = new Microsoft.Win32.OpenFileDialog
 		 {
-		  Title = "选择技能文件",
-		  Filter = "文本文件 (*.md;*.txt)|*.md;*.txt|所有文件 (*.*)|*.*",
+		  Title = PreferencesLocalization.Current("Select skill file"),
+		  Filter = PreferencesLocalization.Current("Text files (*.md;*.txt)") + "|*.md;*.txt|" + PreferencesLocalization.Current("All files (*.*)") + "|*.*",
 		  CheckFileExists = true,
 		  Multiselect = true
 		 };
@@ -184,7 +184,7 @@ namespace ForkPlus.UI.UserControls.Preferences
 		   }
 		   catch (Exception ex)
 		   {
-		    MessageBox.Show("加载文件 '" + fileName + "' 失败: " + ex.Message);
+		    MessageBox.Show(PreferencesLocalization.FormatCurrent("Failed to load file '{0}': {1}", fileName, ex.Message));
 		   }
 		  }
 			if (loadedCount > 0)

--- a/src/ForkPlus/UI/UserControls/Preferences/CustomCommandActionViewModel.cs
+++ b/src/ForkPlus/UI/UserControls/Preferences/CustomCommandActionViewModel.cs
@@ -25,17 +25,17 @@ namespace ForkPlus.UI.UserControls.Preferences
 				_action = value;
 				if (Action is ProcessCustomCommandAction processCustomCommandAction)
 				{
-					Title = "Start Process";
+					Title = PreferencesLocalization.Current("Start Process");
 					Details = processCustomCommandAction.Path + " " + processCustomCommandAction.Parameters;
 				}
 				else if (Action is ShCustomCommandAction)
 				{
-					Title = "Bash Command";
-					Details = "Run bash Script";
+					Title = PreferencesLocalization.Current("Bash Command");
+					Details = PreferencesLocalization.Current("Run bash Script");
 				}
 				else if (Action is UrlCustomCommandAction urlCustomCommandAction)
 				{
-					Title = "Open Url";
+					Title = PreferencesLocalization.Current("Open Url");
 					Details = urlCustomCommandAction.Url;
 				}
 				else
@@ -44,8 +44,8 @@ namespace ForkPlus.UI.UserControls.Preferences
 					{
 						throw new InvalidOperationException();
 					}
-					Title = "Cancel";
-					Details = "close dialog";
+					Title = PreferencesLocalization.Current("Cancel");
+					Details = PreferencesLocalization.Current("close dialog");
 				}
 				ToolTip = Title + "\n" + Details;
 				NotifyPropertyChanged("Title");

--- a/src/ForkPlus/UI/UserControls/Preferences/CustomCommandsUserControl.xaml.cs
+++ b/src/ForkPlus/UI/UserControls/Preferences/CustomCommandsUserControl.xaml.cs
@@ -107,7 +107,7 @@ namespace ForkPlus.UI.UserControls.Preferences
 			}
 			else if (customCommandViewModel.Version > 2)
 			{
-				FallbackUserControl.FallbackMessage = "This custom  command was created in a newer version of Fork.\n Please check for updates in order to use it.";
+				FallbackUserControl.FallbackMessage = PreferencesLocalization.Current("This custom  command was created in a newer version of Fork.\n Please check for updates in order to use it.");
 				FallbackUserControl.Show();
 			}
 			else

--- a/src/ForkPlus/UI/UserControls/Preferences/EditCustomActionWindow.xaml.cs
+++ b/src/ForkPlus/UI/UserControls/Preferences/EditCustomActionWindow.xaml.cs
@@ -58,9 +58,9 @@ namespace ForkPlus.UI.UserControls.Preferences
 		public EditCustomActionWindow(CustomCommand customCommand, CustomCommandAction action, bool showCancel)
 		{
 			InitializeComponent();
-			base.DialogTitle = "Edit Action";
-			base.DialogDescription = "Edit custom command action";
-			base.SubmitButtonTitle = "Save";
+			base.DialogTitle = Translate("Edit Action");
+		base.DialogDescription = Translate("Edit custom command action");
+		base.SubmitButtonTitle = Translate("Save");
 			ShScriptTextBox.FontFamily = FontConstants.MonospaceFontFamily;
 			_customCommand = customCommand;
 			_initialAction = action;

--- a/src/ForkPlus/UI/UserControls/Preferences/EditCustomCommandUIControlsWindow.xaml.cs
+++ b/src/ForkPlus/UI/UserControls/Preferences/EditCustomCommandUIControlsWindow.xaml.cs
@@ -26,7 +26,7 @@ namespace ForkPlus.UI.UserControls.Preferences
 			base.ShowHeader = false;
 			_stopComboBoxEvents = true;
 			InitializeComponent();
-			base.SubmitButtonTitle = "Save";
+			base.SubmitButtonTitle = PreferencesLocalization.Current("Save");
 			ObservableCollection<CustomCommandUIControlViewModel> observableCollection = new ObservableCollection<CustomCommandUIControlViewModel>();
 			for (int i = 0; i < controls.Length; i++)
 			{


### PR DESCRIPTION
## 修改内容

### 1. 国际化修复（~65 个文件）

批量修复对话框/窗口中硬编码的英文/中文字符串，统一通过 `PreferencesLocalization.Current/FormatCurrent` 或本地 `Translate` 方法包裹：

- `DialogTitle` / `DialogDescription` / `SubmitButtonTitle` / `CancelButtonTitle`
- `FallbackMessage` / `FallbackTitle`
- ViewModel 的 `Title` / `Details` 属性

涉及 Accounts 登录窗口、GitFlow 窗口、Preferences 自定义命令窗口、各类操作对话框等。

### 2. 未暂存区空修改修复

**根因**：`core.checkStat=default` 让 git 基于 stat 信息报告 Modified，但实际 diff 可能为空。点击该文件时显示一片空白。

**修复**：`FileDiffControl.cs` 中 diff 为 null 时显示 FallbackUserControl 提示「文件无修改」，而非空白 TextDiffControl。新增翻译条目 `"File has no changes"`。

### 3. 主界面刷新性能优化

**根因**：`Window_Activated` 在非 CommitViewMode 下每次切回窗口都全量刷新，无节流。

**修复**：
- 提取 `ShouldSkipActivationRefresh`，所有视图模式统一 10 秒节流
- 之前 CommitViewMode 5 秒节流 → 10 秒；非 CommitViewMode 无节流 → 10 秒

### 4. GitMm 页签性能优化

针对 GitMm 多子仓场景的性能瓶颈：

| 优化项 | 修改前 | 修改后 |
|--------|--------|--------|
| RuntimeStateCacheTtl | 10 秒（缓存形同虚设） | 60 秒 |
| SaveSettings | 每次交互同步写盘 | 1 秒防抖延迟批量保存 |
| UpdateSubrepoTabWidths | 每次 SizeChanged 同步重算 | 0.1 秒防抖 |
| GetDefaultBranch | 每子仓每刷新都跑 git symbolic-ref | 静态缓存 30 分钟 |

### 5. AI commit 信息排队生成修复

**根因**：`OpenAiService.RequestWithRetry` 有两条重试路径——排队长等待（300 秒）和普通重试（3 次 35 秒）。判断走哪条靠 `LooksLikeQueuedWaitMessage` 关键词匹配，但该方法缺少 `busy/overload/rate limit` 等关键词。AI 服务返回这些错误时只走 3 次普通重试就放弃，用户感觉「排队时生成不出来」。

**修复**：
- 扩展 `LooksLikeQueuedWaitMessage` 关键词，与 `IsTransientServiceMessage` 保持一致
- 兜底：瞬时服务错误也走排队路径（30 秒轮询，总等待 300 秒）
- patch 获取失败后加 `return`，不再用 null patch 继续调 AI
- 任务完成回调加 `monitor.IsCanceled` 检查，避免向已失效 UI 写入

## 测试

- JSON 翻译文件语法验证通过（1830 keys，无重复）
- 所有修改文件 using 语句齐全，方法签名正确